### PR TITLE
Add tips tab and rename app to StrideClub

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
-void main() => runApp(const RunClubApp());
+void main() => runApp(const StrideClubApp());
 
-class RunClubApp extends StatelessWidget {
-  const RunClubApp({super.key});
+class StrideClubApp extends StatelessWidget {
+  const StrideClubApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'RunClub',
+      title: 'StrideClub',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         useMaterial3: true,
@@ -28,7 +28,7 @@ class RootScaffold extends StatefulWidget {
 
 class _RootScaffoldState extends State<RootScaffold> {
   int _idx = 0;
-  final _pages = const [RunsPage(), FeedPage(), ProfilePage()];
+  final _pages = const [RunsPage(), FeedPage(), TipsPage(), ProfilePage()];
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +50,11 @@ class _RootScaffoldState extends State<RootScaffold> {
             icon: Icon(Icons.dynamic_feed_outlined),
             selectedIcon: Icon(Icons.dynamic_feed),
             label: 'Feed',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.lightbulb_outline),
+            selectedIcon: Icon(Icons.lightbulb),
+            label: 'Tips',
           ),
           NavigationDestination(
             icon: Icon(Icons.person_outline),
@@ -409,6 +414,43 @@ class FeedPage extends StatelessWidget {
   }
 }
 
+/// -------------------- Tips --------------------
+
+class TipsPage extends StatelessWidget {
+  const TipsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        const SliverAppBar(
+          floating: true,
+          snap: true,
+          title: Text('Running Tips'),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.all(16),
+          sliver: SliverList.separated(
+            itemBuilder: (context, i) {
+              final tip = demoTips[i];
+              return ListTile(
+                title: Text(tip.title),
+                subtitle: Text('${tip.category} • ${tip.description}'),
+                tileColor: Theme.of(context).colorScheme.surfaceVariant,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              );
+            },
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemCount: demoTips.length,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 /// -------------------- Profile --------------------
 
 class ProfilePage extends StatelessWidget {
@@ -565,5 +607,36 @@ final demoPosts = <Post>[
     author: const User('Lina M'),
     text: 'New shoes day ✨ Loving the bounce.',
     timeAgo: '1d',
+  ),
+];
+
+/// -------------------- Demo tips --------------------
+
+class Tip {
+  final String title;
+  final String category;
+  final String description;
+  const Tip({
+    required this.title,
+    required this.category,
+    required this.description,
+  });
+}
+
+final demoTips = <Tip>[
+  const Tip(
+    title: 'Start Slow',
+    category: 'Beginner',
+    description: 'Ease into runs to avoid injury.',
+  ),
+  const Tip(
+    title: 'Fuel Right',
+    category: 'Nutrition',
+    description: 'Eat a balanced meal a few hours before.',
+  ),
+  const Tip(
+    title: 'Speed Work',
+    category: 'Advanced',
+    description: 'Include intervals once a week to build pace.',
   ),
 ];

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,15 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:test_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Tips tab is accessible from navigation bar', (tester) async {
+    await tester.pumpWidget(const StrideClubApp());
+    // Default page should show Upcoming Runs
+    expect(find.text('Upcoming Runs'), findsOneWidget);
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.tap(find.text('Tips'));
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Running Tips'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Rename application to StrideClub and introduce a tips tab in navigation
- Add sample running tips data and UI
- Update widget test to cover new tips navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7a25a108331979ee6fd7bfd3015