### PR TITLE
Add coach login and run management

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+import 'reminder_service.dart';
+
+class RunClubState extends ChangeNotifier {
+  final ReminderService reminderService;
+  RunClubState(this.reminderService)
+      : runs = [...demoRuns],
+        currentUser = const User('You');
+
+  final List<Run> runs;
+  User currentUser;
+
+  bool get isCoach => currentUser.isCoach;
+
+  void signInAsCoach(String name, String password) {
+    if (password == 'coach123') {
+      currentUser = User(name, isCoach: true);
+      notifyListeners();
+    } else {
+      throw Exception('Invalid credentials');
+    }
+  }
+
+  bool isJoined(Run run) {
+    return run.participants.any((p) => p.name == currentUser.name);
+  }
+
+  void toggleJoin(Run run) {
+    if (isJoined(run)) {
+      run.participants.removeWhere((p) => p.name == currentUser.name);
+      reminderService.cancel(run.id);
+    } else {
+      run.participants.add(currentUser);
+      reminderService.scheduleRunReminder(run);
+    }
+    notifyListeners();
+  }
+
+  void createRun({
+    required String title,
+    required String city,
+    required String location,
+    required double distanceKm,
+    required String paceMinPerKm,
+    required DateTime dateTime,
+  }) {
+    final run = Run(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      city: city,
+      location: location,
+      distanceKm: distanceKm,
+      paceMinPerKm: paceMinPerKm,
+      dateTime: dateTime,
+      participants: [],
+    );
+    runs.add(run);
+    notifyListeners();
+  }
+}

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,0 +1,111 @@
+import 'package:intl/intl.dart';
+
+class User {
+  final String name;
+  final bool isCoach;
+  const User(this.name, {this.isCoach = false});
+
+  String get initials {
+    final parts = name.trim().split(' ');
+    if (parts.length == 1) return parts.first.characters.first.toUpperCase();
+    return (parts.first.characters.first + parts.last.characters.first)
+        .toUpperCase();
+  }
+}
+
+class Run {
+  final String id;
+  final String title;
+  final String city;
+  final String location;
+  final double distanceKm;
+  final String paceMinPerKm;
+  final DateTime dateTime;
+  final List<User> participants;
+
+  Run({
+    required this.id,
+    required this.title,
+    required this.city,
+    required this.location,
+    required this.distanceKm,
+    required this.paceMinPerKm,
+    required this.dateTime,
+    required this.participants,
+  });
+
+  String get dateLabel => DateFormat('EEE, d MMM').format(dateTime);
+  String get timeLabel => DateFormat('h:mm a').format(dateTime);
+}
+
+class Post {
+  final User author;
+  final String text;
+  final String timeAgo;
+  const Post({required this.author, required this.text, required this.timeAgo});
+}
+
+final demoRuns = <Run>[
+  Run(
+    id: 'r1',
+    title: 'Sunrise 5K',
+    city: 'Riyadh',
+    location: 'Kingdom Park Gate 3',
+    distanceKm: 5,
+    paceMinPerKm: '5:30',
+    dateTime: DateTime(DateTime.now().year, 11, 12, 6, 0),
+    participants: [
+      const User('Aisha Al Harbi'),
+      const User('Omar Khan'),
+      const User('Lina M'),
+      const User('You'),
+    ],
+  ),
+  Run(
+    id: 'r2',
+    title: 'Corniche 10K',
+    city: 'Jeddah',
+    location: 'Corniche Plaza',
+    distanceKm: 10,
+    paceMinPerKm: '5:45',
+    dateTime: DateTime(DateTime.now().year, 11, 15, 19, 0),
+    participants: [
+      const User('Rami S'),
+      const User('Sara B'),
+      const User('Hassan'),
+    ],
+  ),
+  Run(
+    id: 'r3',
+    title: 'Trail Fun Run',
+    city: 'Abha',
+    location: 'Al Soudah Trailhead',
+    distanceKm: 8,
+    paceMinPerKm: '6:10',
+    dateTime: DateTime(DateTime.now().year, 11, 23, 5, 30),
+    participants: [
+      const User('Maya'),
+      const User('Noura'),
+      const User('Ali'),
+    ],
+  ),
+];
+
+final demoPosts = <Post>[
+  Post(
+    author: const User('Aisha Al Harbi'),
+    text: 'Crushed my intervals today. See you all at the Sunrise 5K! 🏃‍♀️',
+    timeAgo: '2h',
+  ),
+  Post(
+    author: const User('Omar Khan'),
+    text: 'Anyone up for an easy recovery run tomorrow?',
+    timeAgo: '5h',
+  ),
+  Post(
+    author: const User('Lina M'),
+    text: 'New shoes day ✨ Loving the bounce.',
+    timeAgo: '1d',
+  ),
+];
+

--- a/lib/reminder_service.dart
+++ b/lib/reminder_service.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'models.dart';
+
+class ReminderService {
+  final Map<String, Timer> _timers = {};
+
+  void scheduleRunReminder(Run run) {
+    final now = DateTime.now();
+    final dayStart = DateTime(run.dateTime.year, run.dateTime.month, run.dateTime.day, 8);
+    final duration = dayStart.difference(now);
+    if (duration.isNegative) return;
+    _timers[run.id]?.cancel();
+    _timers[run.id] = Timer(duration, () {
+      print('Reminder: ${run.title} today at ${run.timeLabel}');
+    });
+  }
+
+  void cancel(String runId) {
+    _timers.remove(runId)?.cancel();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.1.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,19 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 import 'package:test_app/main.dart';
+import 'package:test_app/app_state.dart';
+import 'package:test_app/reminder_service.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('shows upcoming runs', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => RunClubState(ReminderService()),
+        child: const RunClubApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Upcoming Runs'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add app state with coach sign-in, run creation, join logic, and reminders
- integrate coach sign-in UI and run creation form
- enable participants to join runs and receive same-day reminders

## Testing
- `dart format lib test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb8661108331a6d9747d144144c5